### PR TITLE
feat(bdd): implement Bash-based acceptance testing framework for /status route

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "turbo run build",
     "lint": "eslint .",
     "test": "vitest --run",
-    "dev": "turbo run dev"
+    "dev": "turbo run dev",
+    "test:features": "bash ./tests/apps/backoffice/backend/setup.sh"
   },
   "type": "module",
   "keywords": [],

--- a/src/apps/backoffice/backend/dependency-injection/config.ndjson
+++ b/src/apps/backoffice/backend/dependency-injection/config.ndjson
@@ -1,0 +1,4 @@
+{ "name": "http-server","dependencies": ["router"],"path": "./../HttpServer.js" }
+{ "name": "backoffice-backend-app", "dependencies": ["http-server"], "path": "./../BackofficeBackendApp.js" }
+{ "name": "router", "dependencies": [], "path": "./../routes/Router.js" }
+{ "name": "status-get-route", "dependencies": [], "path": "./../routes/status/StatusGetRouteHandler.js", "label": "routeHandler" }

--- a/src/apps/backoffice/backend/routes/status/StatusGetRouteHandler.ts
+++ b/src/apps/backoffice/backend/routes/status/StatusGetRouteHandler.ts
@@ -6,10 +6,8 @@ export default class StatusGetRouteHandler implements RouterHandler{
   readonly path:string = '/status';
 
   public handle(req:IncomingMessage,res:ServerResponse) {
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({
-      data: 'Hello World!',
-    }));
+    res.writeHead(200);
+    res.end()
   }
 
   public data() {

--- a/src/apps/backoffice/backend/start.ts
+++ b/src/apps/backoffice/backend/start.ts
@@ -1,8 +1,16 @@
 import BackofficeBackendApp from "./BackofficeBackendApp.js";
 import container from "./dependency-injection/di.js";
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 
 try {
-	await container.load("./dependency-injection/config.ndjson")
+
+	const __filename = fileURLToPath(import.meta.url);
+	const __dirname = dirname(__filename);
+
+	const configPath = join(__dirname, 'dependency-injection', 'config.ndjson');
+
+	await container.load(configPath)
 	const app = await container.get('backoffice-backend-app') as unknown as BackofficeBackendApp
 	app.start();
 } catch (e) {

--- a/tests/apps/backoffice/backend/app-end.sh
+++ b/tests/apps/backoffice/backend/app-end.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Resolve the absolute path to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_FILE="$SCRIPT_DIR/.backoffice_backend_app_id"
+
+# Check if the PID file exists
+if [[ ! -f "$PID_FILE" ]]; then
+  echo "⚠️ PID file not found at $PID_FILE. The app may not have started or was already stopped."
+  exit 0
+fi
+
+# Read the stored PID
+MAIN_PID="$(cat "$PID_FILE")"
+
+# Check if the process is running
+if ! ps -p "$MAIN_PID" > /dev/null; then
+  echo "⚠️ No process found with PID $MAIN_PID. Cleaning up..."
+  rm -f "$PID_FILE"
+  exit 0
+fi
+
+echo "🔢 Main PID detected: $MAIN_PID"
+echo "🔍 Searching for child processes..."
+
+# Recursively kill all subprocesses
+kill_tree() {
+  local parent_pid=$1
+  local children
+  children=$(ps --ppid "$parent_pid" -o pid= | xargs || true)
+
+  for child_pid in $children; do
+    kill_tree "$child_pid"
+  done
+
+  echo "❌ Killing PID $parent_pid"
+  kill "$parent_pid" 2>/dev/null || true
+}
+
+kill_tree "$MAIN_PID"
+
+# Remove the PID file
+rm -f "$PID_FILE"
+echo "✅ All processes successfully terminated."

--- a/tests/apps/backoffice/backend/app-start.sh
+++ b/tests/apps/backoffice/backend/app-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Resolve the absolute path of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_FILE="$SCRIPT_DIR/.backoffice_backend_app_id"
+
+# Compute the project root by going 4 levels up from backend/
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Entry point TypeScript file
+START_FILE_PATH="$ROOT_DIR/src/apps/backoffice/backend/start.ts"
+
+echo "📁 Starting app from: $START_FILE_PATH"
+echo "📦 Project root: $ROOT_DIR"
+
+# Launch the TypeScript app in the background using tsx
+tsx "$START_FILE_PATH" &
+
+TSX_PID="$!"
+sleep 1  # Allow tsx to spawn the Node process
+
+# Try to get the actual Node process PID (child of tsx)
+MAIN_PID=$(pgrep -P "$TSX_PID" node || echo "$TSX_PID")
+
+# Save the PID to file for later cleanup
+echo "$MAIN_PID" > "$PID_FILE"
+echo "✅ Saved PID in $PID_FILE: $MAIN_PID"

--- a/tests/apps/backoffice/backend/features/status/00-info.sh
+++ b/tests/apps/backoffice/backend/features/status/00-info.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo -e "\tchecking server is up and running"
+echo -e "\tgiven I send a GET request to http://localhost:3000/status"
+echo -e "\tstatus code should be 200 OK"
+echo -e "\tresponse body should be empty"

--- a/tests/apps/backoffice/backend/features/status/01-code.sh
+++ b/tests/apps/backoffice/backend/features/status/01-code.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+<<com
+-s silent mode dont output any kind of progress bar like
+      % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                      Dload  Upload   Total   Spent    Left  Speed
+      100    27  100    27    0     0  13500      0 --:--:-- --:--:-- --:--:-- 13500
+
+-o output file. Redirect output body (not headers) into /dev/null file its not necessary
+
+-w write format. curl flag that enables to output specific data into stdout base on variables
+com
+
+echo -e "\tchecking status code..."
+echo -e "\texpected to be 200"
+
+status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/status)
+
+if [ "$status" -eq 200 ]; then
+  echo -e "\t✅ Status OK ($status)"
+else
+  echo -e "\t❌ Unexpected status: $status"
+  exit 1
+fi

--- a/tests/apps/backoffice/backend/features/status/02-response-body.sh
+++ b/tests/apps/backoffice/backend/features/status/02-response-body.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo -e "\tchecking response body..."
+echo -e "\texpected to be empty"
+
+body=$(curl -s http://localhost:3000/status)
+
+if [ -z "$body" ]; then
+  echo -e "\t✅ Body is empty"
+else
+  echo -e "\t❌ Body is NOT empty: '$body'"
+  exit 1
+fi

--- a/tests/apps/backoffice/backend/setup.sh
+++ b/tests/apps/backoffice/backend/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Exit when a non-zero value is exited
+set -e 
+
+
+# BASH_SOURCE is a Bash internal array variable.
+# It contains the script file paths, as they were specified when invoked (relative or absolute).
+BASE_SCRIPT_DIRNAME="$(dirname "$BASH_SOURCE[0]")"
+
+# Get the absolute path to the directory where the BDD scripts are located.
+# BASE_SOURCE may be a relative or absolute path, depending on how the script was invoked.
+SCRIPT_DIR="$(cd "$BASE_SCRIPT_DIRNAME" && pwd)"
+
+# Execute app-end after app-start has been executed to finish all starting processes
+trap "bash \"$SCRIPT_DIR/app-end.sh\"" EXIT
+
+# Give execute permissions to all .sh files located in $SCRIPT_DIR
+find "$SCRIPT_DIR" -type f -name "*.sh" -exec chmod +x {} \;
+
+echo "🔄 Starting app..."
+bash "$SCRIPT_DIR/app-start.sh"
+
+echo
+for feature_dir in "$SCRIPT_DIR/features"/*; do
+  if [ -d "$feature_dir" ]; then
+    echo "🚀 Running tests in $(basename "$feature_dir")"
+    
+    for script in "$feature_dir"/*.sh; do
+      echo "▶️ Executing $(basename "$script")"
+      bash "$script"
+      echo
+      sleep 0.25
+    done
+  fi
+done


### PR DESCRIPTION
- Add Bash-based BDD test runner in `setup.sh`, with support for app startup, test execution, and teardown.
- Implement `app-start.sh` to launch the backend using tsx and capture its PID for later shutdown.
- Implement `app-end.sh` to recursively kill the backend process tree and ensure cleanup via trap.
- Add `/status` acceptance test suite under `features/status/`:
  - 00-info.sh documents the test scenario
  - 01-code.sh asserts 200 OK response
  - 02-response-body.sh asserts empty response body
- Update `package.json` scripts:
  - `test:features`: run BDD tests using `setup.sh`
- Simplify `/status` endpoint response to return 200 OK with no body
- Load DI config via absolute path resolution in `start.ts` using `import.meta.url`
- Add `config.ndjson` to define DI container graph with services:
  - `backoffice-backend-app`
  - `http-server`
  - `router`
  - `status-get-route`