### PR TITLE
feat(command-bus): introduce in-memory CommandBus with handler registry and error handling

### DIFF
--- a/src/shared/domain/NewableClass.ts
+++ b/src/shared/domain/NewableClass.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type NewableClass<T> = new (...args: any[]) => T;

--- a/src/shared/domain/command/Command.ts
+++ b/src/shared/domain/command/Command.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export default interface Command {}
+export abstract class Command {}

--- a/src/shared/domain/command/Command.ts
+++ b/src/shared/domain/command/Command.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export default interface Command {}

--- a/src/shared/domain/command/CommandBus.ts
+++ b/src/shared/domain/command/CommandBus.ts
@@ -1,0 +1,5 @@
+import Command from "./Command";
+
+export  default interface CommandBus {
+  dispatch(_:Command): Promise<void>;
+}

--- a/src/shared/domain/command/CommandBus.ts
+++ b/src/shared/domain/command/CommandBus.ts
@@ -1,5 +1,5 @@
-import Command from "./Command";
+import { Command } from './Command';
 
-export  default interface CommandBus {
-  dispatch(_:Command): Promise<void>;
+export interface CommandBus {
+  dispatch(command: Command): Promise<void>;
 }

--- a/src/shared/domain/command/CommandBus.ts
+++ b/src/shared/domain/command/CommandBus.ts
@@ -1,5 +1,5 @@
 import { Command } from './Command';
 
-export interface CommandBus {
+export default interface  CommandBus {
   dispatch(command: Command): Promise<void>;
 }

--- a/src/shared/domain/command/CommandHandler.ts
+++ b/src/shared/domain/command/CommandHandler.ts
@@ -1,5 +1,6 @@
-import Command from "./Command";
+import { Command } from './Command';
 
-export default interface CommandHandler<T extends Command>{
-  handle(_:T):Promise<void>;
+export interface CommandHandler<T extends Command> {
+  subscribedTo(): Command;
+  handle(command: T): Promise<void>;
 }

--- a/src/shared/domain/command/CommandHandler.ts
+++ b/src/shared/domain/command/CommandHandler.ts
@@ -1,0 +1,5 @@
+import Command from "./Command";
+
+export default interface CommandHandler<T extends Command>{
+  handle(_:T):Promise<void>;
+}

--- a/src/shared/domain/command/CommandNotFoundError.ts
+++ b/src/shared/domain/command/CommandNotFoundError.ts
@@ -1,0 +1,8 @@
+import { Command } from './Command';
+import { CommandHandler } from './CommandHandler';
+
+export class CommandNotFoundError extends Error {
+  constructor(handler: CommandHandler<Command>) {
+    super(`The command hasn't been found in the handlers <${handler.constructor.name}> suscribedTo method`);
+  }
+}

--- a/src/shared/domain/command/CommandNotRegisteredError.ts
+++ b/src/shared/domain/command/CommandNotRegisteredError.ts
@@ -1,0 +1,7 @@
+import { Command } from './Command';
+
+export class CommandNotRegisteredError extends Error {
+  constructor(command: Command) {
+    super(`The command <${command.constructor.name}> hasn't a command handler associated`);
+  }
+}

--- a/src/shared/infrastructure/command/CommandHandlers.ts
+++ b/src/shared/infrastructure/command/CommandHandlers.ts
@@ -1,0 +1,33 @@
+import { Command } from "../../domain/command/Command";
+import { CommandHandler } from "../../domain/command/CommandHandler";
+import { CommandNotRegisteredError } from "../../domain/command/CommandNotRegisteredError";
+import { CommandNotFoundError } from "../../domain/command/CommandNotFoundError";
+
+
+export class CommandHandlers  {
+  private readonly commandToHandlerRelation = new Map<Command, CommandHandler<Command>>();
+
+  constructor(commandHandlers: CommandHandler<Command>[]) {
+    commandHandlers.forEach(commandHandler => {
+      this.set(commandHandler);
+    });
+  }
+
+  private set(handler:CommandHandler<Command>):void {
+    const command = handler.subscribedTo()
+    
+    if(!command) throw new CommandNotFoundError(handler);
+    
+    this.commandToHandlerRelation.set(handler.subscribedTo(), handler);
+  }
+
+  public get(command: Command): CommandHandler<Command> {
+    const commandHandler = this.commandToHandlerRelation.get(command.constructor);
+
+    if (!commandHandler) {
+      throw new CommandNotRegisteredError(command);
+    }
+
+    return commandHandler;
+  }
+}

--- a/src/shared/infrastructure/command/InMemoryAsyncCommandBus.ts
+++ b/src/shared/infrastructure/command/InMemoryAsyncCommandBus.ts
@@ -1,0 +1,13 @@
+import { Command } from '../../domain/command/Command';
+import CommandBus from './../../domain/command/CommandBus'
+import { CommandHandlers } from './CommandHandlers';
+
+export class InMemoryCommandBus implements CommandBus {
+  constructor(private commandHandlers: CommandHandlers) {}
+
+  async dispatch(command: Command): Promise<void> {
+    const handler = this.commandHandlers.get(command);
+
+    await handler.handle(command);
+  }
+}


### PR DESCRIPTION
# 📝 PR Description:
This merge introduces a complete command dispatching system following CQRS and Dependency Inversion principles. The new architecture is built around a CommandBus abstraction with support for runtime validation, custom errors, and a centralized handler registry.

## ✨ What's included:

### CommandBus interface: 
- Defines the contract for command dispatching.

### InMemoryCommandBus: 
- Concrete implementation that resolves handlers via a registry.

### CommandHandlers: 
- Internal map of commands to handlers, supporting validation at registration and dispatch time.

## Custom errors:

### CommandNotFoundError: 
- Thrown when a handler doesn’t declare a subscribed command.

### CommandNotRegisteredError: 
- Thrown when a command is dispatched without a registered handler.

##Shared type utility: 

### NewableClass
- Rrepresents generic instantiable types with new.

This lays the foundation for a decoupled command-processing layer that is fully extensible and testable.