### PR TITLE
feat(query): implement async QueryBus and handler registry for CQRS support

### DIFF
--- a/src/shared/domain/query/Query.ts
+++ b/src/shared/domain/query/Query.ts
@@ -1,0 +1,1 @@
+export default abstract class Query {}

--- a/src/shared/domain/query/QueryBus.ts
+++ b/src/shared/domain/query/QueryBus.ts
@@ -1,0 +1,7 @@
+import Query from "./Query";
+import Response from "./Response";
+
+
+export default interface QueryBus {
+  ask<Q extends Query, R extends Response>(query:Q): Promise<R>
+}

--- a/src/shared/domain/query/QueryHandler.ts
+++ b/src/shared/domain/query/QueryHandler.ts
@@ -1,0 +1,6 @@
+import Query from "./Query";
+
+export default interface QueryHandler<Q extends Query, R extends Response> {
+  subscribedTo(): Query;
+  handle(query:Q): Promise<R>;
+}

--- a/src/shared/domain/query/QueryNotFoundError.ts
+++ b/src/shared/domain/query/QueryNotFoundError.ts
@@ -1,0 +1,9 @@
+import Query  from './Query';
+import Response from './Response';
+import  QueryHandler from './QueryHandler';
+
+export default class QueryNotFoundError extends Error {
+  constructor(handler: QueryHandler<Query, Response>) {
+    super(`The query hasn't been found in the handlers <${handler.constructor.name}> suscribedTo method`);
+  }
+}

--- a/src/shared/domain/query/QueryNotRegisteredError.ts
+++ b/src/shared/domain/query/QueryNotRegisteredError.ts
@@ -1,0 +1,7 @@
+import Query from './Query';
+
+export default class QueryNotRegisteredError extends Error {
+  constructor(query: Query) {
+    super(`The query <${query.constructor.name}> hasn't a command handler associated`);
+  }
+}

--- a/src/shared/domain/query/Response.ts
+++ b/src/shared/domain/query/Response.ts
@@ -1,0 +1,1 @@
+export default abstract class Response {}

--- a/src/shared/infrastructure/query/InMemoryAsyncQueryBus.ts
+++ b/src/shared/infrastructure/query/InMemoryAsyncQueryBus.ts
@@ -1,0 +1,14 @@
+import Query from "../../domain/query/Query";
+import QueryBus from "../../domain/query/QueryBus";
+import Response from "../../domain/query/Response";
+import QueryHandlers from "./QueryHandlers";
+
+export default class InMemoryAsyncQueryBus implements QueryBus{
+  constructor (private queryHandlers: QueryHandlers){}
+  
+  async ask<Q extends Query, R extends Response>(query: Q): Promise<R> {
+    const queryHandler = this.queryHandlers.get(query);
+
+    return await queryHandler.handle(query) as Promise<R>
+  }
+}

--- a/src/shared/infrastructure/query/QueryHandlers.ts
+++ b/src/shared/infrastructure/query/QueryHandlers.ts
@@ -1,0 +1,34 @@
+import Query from "../../domain/query/Query";
+import Response from "../../domain/query/Response";
+import QueryHandler from "../../domain/query/QueryHandler";
+import QueryNotFoundError from "../../domain/query/QueryNotFoundError";
+import QueryNotRegisteredError from "../../domain/query/QueryNotRegisteredError";
+
+
+export default class QueryHandlers {
+private readonly queryToHandlerRelation = new Map<Query, QueryHandler<Query, Response>>();
+
+  constructor(queryHandlers: QueryHandler<Query, Response>[]) {
+    queryHandlers.forEach(queryHandler => {
+      this.set(queryHandler);
+    });
+  }
+
+  private set(handler:QueryHandler<Query, Response>):void {
+    const query = handler.subscribedTo()
+    
+    if(!query) throw new QueryNotFoundError(handler);
+    
+    this.queryToHandlerRelation.set(handler.subscribedTo(), handler);
+  }
+
+  public get(query: Query): QueryHandler<Query, Response> {
+    const queryHandler = this.queryToHandlerRelation.get(query.constructor);
+
+    if (!queryHandler) {
+      throw new QueryNotRegisteredError(query);
+    }
+
+    return queryHandler;
+  }
+}


### PR DESCRIPTION
# 📝 PR Description
This PR introduces a complete in-memory Query Bus infrastructure to support the read side of a CQRS (Command Query Responsibility Segregation) architecture.

# ✨ What’s Included

## Query
- Abstract base class to represent a query in the system.

## Response
- Abstract base class representing the return type of a query.

## QueryHandler<Q, R>
- Interface that binds a query type Q to a response type R.

### Includes:
- subscribedTo(): returns the associated query type.
- handle(query): handles the query and returns a response.

## QueryBus
- Interface with method ask(query) to execute a query asynchronously.

## QueryHandlers
- Maps queries to their corresponding handlers.
- Ensures correct handler is used at runtime.

### Throws:
- QueryNotFoundError → if a handler doesn’t declare a query via subscribedTo().
- QueryNotRegisteredError → if a query is dispatched without any associated handler.

## InMemoryAsyncQueryBus
- A working in-memory implementation of QueryBus using the registry above.